### PR TITLE
Extract UI code to autoload

### DIFF
--- a/autoload/cpp_plugin.vim
+++ b/autoload/cpp_plugin.vim
@@ -107,6 +107,16 @@ function! s:RemoveFuntionModifiers (str) abort
 
 endfunction
 
+function! cpp_plugin#InitUserInterface() abort
+    nnoremap <buffer> <Leader>cad :call cpp_plugin#CreateFunctionDefinition()<CR>
+
+    command! -buffer Big6 :call cpp_plugin#DeclareBig6()<CR>
+
+    nnoremap <buffer> <Leader>es :call cpp_plugin#ExpandSnippet()<CR>
+    inoremap <buffer> { {<C-O>:call cpp_plugin#AddBraceAndIndentation()<CR>
+    nnoremap <buffer> <Leader>bp :call cpp_plugin#ChangeBracketPos()<CR>
+endfunction
+
 function! cpp_plugin#CreateFunctionDefinition() abort
     let savedView = winsaveview()
     let currentLine = substitute(getline('.'), '^\s*', '', '') " get the current line and remove tabs

--- a/ftplugin/cpp/cpp_plugin.vim
+++ b/ftplugin/cpp/cpp_plugin.vim
@@ -1,18 +1,7 @@
-" Ако сме в compatible mode или plugin-ът е зареден, finish 
-if exists('g:loaded_cpp_plugin') || &cp
-	finish
-endif
-let g:loaded_cpp_plugin = '0.0.1' 
 let s:keepcpo = &cpo
 set cpo&vim
 
-nnoremap <Leader>cad :call cpp_plugin#CreateFunctionDefinition()<CR>
+call cpp_plugin#InitUserInterface()
 
-command! Big6 :call cpp_plugin#DeclareBig6()<CR>
-
-nnoremap <Leader>es :call cpp_plugin#ExpandSnippet()<CR>
-inoremap { {<C-O>:call cpp_plugin#AddBraceAndIndentation()<CR>
-nnoremap <Leader>bp :call cpp_plugin#ChangeBracketPos()<CR>
-
-let &cpo = s:keepcpo 
+let &cpo = s:keepcpo
 unlet s:keepcpo

--- a/ftplugin/h/cpp_plugin.vim
+++ b/ftplugin/h/cpp_plugin.vim
@@ -1,18 +1,7 @@
-" Ако сме в compatible mode или plugin-ът е зареден, finish 
-if exists('g:loaded_cpp_plugin') || &cp
-	finish
-endif
-let g:loaded_cpp_plugin = '0.0.1' 
 let s:keepcpo = &cpo
 set cpo&vim
 
-nnoremap <Leader>cad :call cpp_plugin#CreateFunctionDefinition()<CR>
+call cpp_plugin#InitUserInterface()
 
-command! Big6 :call cpp_plugin#DeclareBig6()<CR>
-
-nnoremap <Leader>es :call cpp_plugin#ExpandSnippet()<CR>
-inoremap { {<C-O>:call cpp_plugin#AddBraceAndIndentation()<CR>
-nnoremap <Leader>bp :call cpp_plugin#ChangeBracketPos()<CR>
-
-let &cpo = s:keepcpo 
+let &cpo = s:keepcpo
 unlet s:keepcpo

--- a/ftplugin/hpp/cpp_plugin.vim
+++ b/ftplugin/hpp/cpp_plugin.vim
@@ -1,18 +1,7 @@
-" Ако сме в compatible mode или plugin-ът е зареден, finish 
-if exists('g:loaded_cpp_plugin') || &cp
-	finish
-endif
-let g:loaded_cpp_plugin = '0.0.1' 
 let s:keepcpo = &cpo
 set cpo&vim
 
-nnoremap <Leader>cad :call cpp_plugin#CreateFunctionDefinition()<CR>
+call cpp_plugin#InitUserInterface()
 
-command! Big6 :call cpp_plugin#DeclareBig6()<CR>
-
-nnoremap <Leader>es :call cpp_plugin#ExpandSnippet()<CR>
-inoremap { {<C-O>:call cpp_plugin#AddBraceAndIndentation()<CR>
-nnoremap <Leader>bp :call cpp_plugin#ChangeBracketPos()<CR>
-
-let &cpo = s:keepcpo 
+let &cpo = s:keepcpo
 unlet s:keepcpo


### PR DESCRIPTION
Тъй като кода за трите различни filetype-а е един и същ, има смисъл да се дръпне в обща функция и просто да се извика в трите файла.

Отделно, тези команди и мапинги има смисъл да бъдат buffer-локални с `<buffer>` за мапингите и `-buffer` за командите. Така няма да бъдат дефинирани за други файлове, където няма да могат да работят правилно.

Логиката за `if exists('g:loaded_cpp_plugin')` тогава има смисъл да се махне, защото *искаш* да се дефинират функциите като се отвори нов буфер. Има смисъл за някакъв глобален инитиализиращ код в `plugin/`, но не е много полезна за filetype-специфични неща.